### PR TITLE
Check the existence of the images_path

### DIFF
--- a/planetstack/openstack_observer/steps/sync_images.py
+++ b/planetstack/openstack_observer/steps/sync_images.py
@@ -17,11 +17,14 @@ class SyncImages(OpenStackSyncStep):
             return []
 
         # get list of images on disk
-        images_path = Config().observer_images_directory 
+        images_path = Config().observer_images_directory
+
         available_images = {}
-        for f in os.listdir(images_path):
-            if os.path.isfile(os.path.join(images_path ,f)):
-                available_images[f] = os.path.join(images_path ,f)
+        if os.path.exists(images_path):
+            for f in os.listdir(images_path):
+                filename = os.path.join(images_path, f)
+                if os.path.isfile(filename):
+                    available_images[f] = filename
 
         images = Image.objects.all()
         image_names = [image.name for image in images]
@@ -35,8 +38,7 @@ class SyncImages(OpenStackSyncStep):
                               container_format='bare', 
                               path = available_images[image_name])
                 image.save()
-       
-        
+
         return Image.objects.filter(Q(enacted__lt=F('updated')) | Q(enacted=None)) 
 
     def sync_record(self, image):


### PR DESCRIPTION
ERROR:planetstack.log:[Errno 2] No such file or directory: '/opt/xos/images' BEG TRACEBACK
Traceback (most recent call last):
  File "/opt/xos/observer/event_loop.py", line 349, in sync
    failed_objects = sync_step(failed=list(self.failed_step_objects), deletion=deletion)
  File "/opt/xos/observer/openstacksyncstep.py", line 14, in __call__
    return self.call(**args)
  File "/opt/xos/observer/syncstep.py", line 97, in call
    pending = self.fetch_pending(deletion)
  File "/opt/xos/observer/steps/sync_images.py", line 22, in fetch_pending
    for f in os.listdir(images_path):
OSError: [Errno 2] No such file or directory: '/opt/xos/images'
ERROR:planetstack.log:[Errno 2] No such file or directory: '/opt/xos/images' END TRACEBACK

Signed-off-by: S.Çağlar Onur <caglar@10ur.org>