### PR TITLE
admin page port number+login typo

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -29,7 +29,7 @@ $ cd xos; make build && make run
 ```
 
 You should now be able to access the login page by visiting
-`http://localhost:80` and log in using the default `paadmin@vicci.org` account
+`http://localhost:8000` and log in using the default `padmin@vicci.org` account
 with password `letmein`. It may be helpful to bootstrap xos with some sample
 data; deployment, controllers, sites, slices, etc. You can get started by
 loading tosca configuration for the opencloud demo dataset:


### PR DESCRIPTION
port number should be 8000 (based on the Docker runtime port binding option in the makefile)
and login should be padmin@vicci.org