### PR TITLE
openstackclient version is unmatched

### DIFF
--- a/xos/configurations/common/Makefile.devstack
+++ b/xos/configurations/common/Makefile.devstack
@@ -15,7 +15,7 @@ admin-openrc:
 
 flat_name:
 	echo private|tr -d '\n' > $(SETUPDIR)/flat_net_name
-	bash -c "source $(SETUPDIR)/admin-openrc.sh; openstack network set --share private"
+	bash -c "source $(SETUPDIR)/admin-openrc.sh; neutron net-update private --shared"
 
 nodes_yaml:
 	export SETUPDIR=$(SETUPDIR); bash ./make-nodes-yaml.sh


### PR DESCRIPTION
For current installation process, command "openstack network set --share private" does not work because openstackclient version is unmatched.
To avoid this issue, line 18 in xos/xos/configurations/common/Makefile.devstack should be changed as following.

from
```
bash -c "source $(SETUPDIR)/admin-openrc.sh; openstack network set --share private"
```
to
 ```
bash -c "source $(SETUPDIR)/admin-openrc.sh; neutron net-update private --shared"
```