### PR TITLE
Write django and ansible debug logs to disk

### DIFF
--- a/xos/configurations/common/xos_common_config
+++ b/xos/configurations/common/xos_common_config
@@ -37,6 +37,7 @@ backoff_disabled=True
 images_directory=/opt/xos/images
 dependency_graph=/opt/xos/model-deps
 logfile=/var/log/xos_backend.log
+save_ansible_output=True
 
 [gui]
 disable_minidashboard=True

--- a/xos/xos/settings.py
+++ b/xos/xos/settings.py
@@ -176,7 +176,6 @@ INSTALLED_APPS = (
     'services.hpc',
     'services.cord',
     'services.helloworldservice_complete',
-    'services.exampleservice',
     'services.onos',
     'services.ceilometer',
     'services.requestrouter',

--- a/xos/xos/settings.py
+++ b/xos/xos/settings.py
@@ -176,6 +176,7 @@ INSTALLED_APPS = (
     'services.hpc',
     'services.cord',
     'services.helloworldservice_complete',
+    'services.exampleservice',
     'services.onos',
     'services.ceilometer',
     'services.requestrouter',
@@ -209,13 +210,23 @@ LOGGING = {
         }
     },
     'handlers': {
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': '/var/log/django_debug.log',
+        },
         'mail_admins': {
             'level': 'ERROR',
             'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler'
-        }
+        },
     },
     'loggers': {
+        'django': {
+            'handlers': ['file'],
+            'level': 'DEBUG',
+            'propagate': True,
+        },
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',


### PR DESCRIPTION
While we probably want to enable this depending on configuration, these two commits make it so that logs are written to disk for Django and Ansible, which greatly aids in debugging new services.

Previously Django logging wasn't enabled, and Ansible logging was turned on only for specific configurations.